### PR TITLE
Fix Horner searchData row lookup by duration

### DIFF
--- a/Horner/index.html
+++ b/Horner/index.html
@@ -89,10 +89,10 @@
             let table = '<table><thead><tr><th>重現期\\延時</th>' + dropdownData.durations.map(d => `<th>${d}</th>`).join('') + '</tr></thead><tbody>';
 
             recurSet.forEach(rp => {
-                const row = filtered.find(r => r['重期期距(年)'] == rp);
                 table += '<tr>' +
                     `<td>${rp}</td>` +
                     dropdownData.durations.map(d => {
+                        const row = filtered.find(r => r['重期期距(年)'] == rp && r['延時'] == d);
                         const val = row ? parseFloat(row[d + '_accum']).toFixed(1) : '-';
                         const cls = (rp == recur && d === duration) ? 'highlight' : '';
                         return `<td class="${cls}">${val}</td>`;


### PR DESCRIPTION
## Summary
- Ensure table cells use records matching both recurrence period and duration.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/OpenData/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_688f743864f48331944506fddaaa82d0